### PR TITLE
Restrict loading indicator to production environment

### DIFF
--- a/src/components/auth/GoogleLogin.tsx
+++ b/src/components/auth/GoogleLogin.tsx
@@ -25,7 +25,7 @@ export function GoogleLoginBtn() {
 
                 </Box>
             )}
-            {isLoading && (
+            {isLoading && import.meta.env.VITE_ENV === "prod" &&(
                 <Box display={"flex"} justifyContent={"center"} alignItems={"center"} mt={4} flexDirection={"column"}>
                     <CircularProgress/>
                 </Box>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -22,7 +22,7 @@ export function HomePage() {
                     <CircularProgress/>
                 </Box>
             )}
-            {isLoading && (
+            {isLoading && import.meta.env.VITE_ENV === "prod" && (
                 <Box display={"flex"} justifyContent={"center"} alignItems={"center"} mt={4} flexDirection={"column"}>
                     s<CircularProgress/>
                 </Box>


### PR DESCRIPTION
Loading spinners now only render when the `VITE_ENV` is set to "prod". This prevents unnecessary UI changes in non-production environments, improving the development experience.